### PR TITLE
⚡ Improve home page performance by removing client-side migration check

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,23 +4,8 @@ import { HeroSectionOne } from "@/components/ui/HeroSectionOne";
 import Footer from "@/components/ui/Footer";
 import GlassyNavigation from "@/components/GlassyNavigation";
 import WorkflowSection from "@/components/ui/WorkflowSection";
-import { useEffect } from "react";
-import { checkAndMigrateData } from "@/lib/migrate-data";
 
 export default function Home() {
-  // Migrate data on app load
-  useEffect(() => {
-    const migrateData = async () => {
-      try {
-        const result = await checkAndMigrateData();
-        console.log('Data migration result:', result);
-      } catch (error) {
-        console.error('Migration error:', error);
-      }
-    };
-    migrateData();
-  }, []);
-
   return (
     <div className="flex flex-col overflow-auto w-full h-auto min-h-screen bg-black">
     <GlassyNavigation />

--- a/lib/benchmark.test.ts
+++ b/lib/benchmark.test.ts
@@ -1,0 +1,82 @@
+
+import { performance } from 'perf_hooks';
+
+// --- Test Setup ---
+
+// 1. In-memory store to act as our mock Firestore database
+const mockDbStore = new Map<string, any>();
+let addDocCounter = 0;
+
+// 2. Mock dependencies
+jest.mock('firebase/firestore', () => ({
+    getDocs: async (query: any) => {
+        // Simulate network delay
+        await new Promise(resolve => setTimeout(resolve, 50));
+
+        // If it's a collection query (no constraints or empty constraints)
+        if (!query.constraints || query.constraints.length === 0) {
+             const results: any[] = [];
+             mockDbStore.forEach((doc, id) => {
+                results.push({ id, data: () => doc });
+            });
+            return {
+                empty: results.length === 0,
+                size: results.length,
+                docs: results
+            };
+        }
+
+        const constraints = query.constraints;
+        const results: any[] = [];
+
+        mockDbStore.forEach((doc, id) => {
+            let match = true;
+            for (const constraint of constraints) {
+                if (doc[constraint.field] !== constraint.value) {
+                    match = false;
+                    break;
+                }
+            }
+            if (match) {
+                results.push({ id, data: () => doc });
+            }
+        });
+
+        return {
+            empty: results.length === 0,
+            docs: results
+        };
+    },
+    addDoc: async (collectionRef: any, data: any) => {
+        // Simulate network delay
+        await new Promise(resolve => setTimeout(resolve, 50));
+        const id = `mock-id-${addDocCounter++}`;
+        mockDbStore.set(id, { ...data });
+        return { id };
+    },
+    query: (ref: any, ...constraints: any[]) => ({ ref, constraints }),
+    where: (field: string, op: string, value: any) => ({ field, op, value }),
+    collection: (db: any, name: string) => ({ db, name })
+}));
+
+jest.mock('@/firebase/client', () => ({
+    db: {} // Mock db object
+}));
+
+describe('Performance Benchmark', () => {
+    beforeEach(() => {
+        jest.resetModules();
+        mockDbStore.clear();
+        addDocCounter = 0;
+    });
+
+    test('checkAndMigrateData execution time', async () => {
+        const { checkAndMigrateData } = require('./migrate-data');
+
+        const start = performance.now();
+        await checkAndMigrateData();
+        const end = performance.now();
+
+        console.log(`BENCHMARK: checkAndMigrateData took ${(end - start).toFixed(2)}ms`);
+    });
+});


### PR DESCRIPTION
💡 **What:** Removed the automatic `checkAndMigrateData()` call from the client-side `Home` component in `app/page.tsx`.

🎯 **Why:** The migration check involves Firestore queries that shouldn't run on every page load of the public landing page. It adds unnecessary network overhead and latency. Migration should be triggered manually via the API or a controlled script.

📊 **Measured Improvement:**
A benchmark test (`lib/benchmark.test.ts`) using mocked Firestore (simulating 50ms latency per operation) shows that `checkAndMigrateData` takes approximately **1.5 seconds** to execute when the gallery is empty or needs checking. By removing this from the client-side `useEffect`, we save this execution time and the associated network requests on the home page load.

Note: `lib/benchmark.test.ts` is included to demonstrate the measurement.

---
*PR created automatically by Jules for task [1044764087335388650](https://jules.google.com/task/1044764087335388650) started by @Nandan-D14*