### PR TITLE
⚡ Optimize getStats with getCountFromServer

### DIFF
--- a/lib/firebase-service.stats.test.ts
+++ b/lib/firebase-service.stats.test.ts
@@ -1,0 +1,76 @@
+
+import { firebaseService } from './firebase-service';
+import { getDocs, getCountFromServer, collection, query, orderBy, limit } from 'firebase/firestore';
+
+// Mock dependencies
+jest.mock('@/firebase/client', () => ({
+  auth: {},
+  db: {},
+}));
+
+jest.mock('firebase/auth', () => ({
+  getAuth: jest.fn(),
+  GoogleAuthProvider: jest.fn(),
+  createUserWithEmailAndPassword: jest.fn(),
+  signInWithEmailAndPassword: jest.fn(),
+  signInWithRedirect: jest.fn(),
+  getRedirectResult: jest.fn(),
+  signOut: jest.fn(),
+  updateProfile: jest.fn(),
+  sendPasswordResetEmail: jest.fn(),
+  onAuthStateChanged: jest.fn(),
+}));
+
+jest.mock('firebase/firestore', () => ({
+  getDocs: jest.fn(),
+  getCountFromServer: jest.fn(),
+  collection: jest.fn(),
+  query: jest.fn(),
+  orderBy: jest.fn(),
+  limit: jest.fn(),
+  doc: jest.fn(),
+  setDoc: jest.fn(),
+  getDoc: jest.fn(),
+  updateDoc: jest.fn(),
+  addDoc: jest.fn(),
+  Timestamp: {
+    now: jest.fn(),
+  },
+}));
+
+describe('FirebaseService.getStats', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should use getCountFromServer for counts and getDocs for recent items', async () => {
+    // Setup mocks
+    (getCountFromServer as jest.Mock).mockResolvedValue({
+      data: () => ({ count: 42 })
+    });
+
+    (getDocs as jest.Mock).mockResolvedValue({
+      size: 2,
+      docs: [
+        { id: '1', data: () => ({ title: 'Item 1' }) },
+        { id: '2', data: () => ({ title: 'Item 2' }) }
+      ]
+    });
+
+    const stats = await firebaseService.getStats();
+
+    // Verify optimized behavior
+    expect(getCountFromServer).toHaveBeenCalledTimes(2);
+    expect(getDocs).toHaveBeenCalledTimes(1);
+
+    // Verify result structure
+    expect(stats).toEqual({
+      totalUsers: 42,
+      totalGalleryItems: 42,
+      recentItems: [
+        { id: '1', title: 'Item 1' },
+        { id: '2', title: 'Item 2' }
+      ]
+    });
+  });
+});

--- a/lib/firebase-service.ts
+++ b/lib/firebase-service.ts
@@ -20,6 +20,7 @@ import {
   collection,
   addDoc,
   getDocs,
+  getCountFromServer,
   query,
   orderBy,
   limit,
@@ -409,14 +410,14 @@ export class FirebaseService {
   async getStats(): Promise<{ totalUsers: number; totalGalleryItems: number; recentItems: any[] }> {
     try {
       const [usersSnapshot, gallerySnapshot, recentItemsSnapshot] = await Promise.all([
-        getDocs(collection(db, "users")),
-        getDocs(collection(db, "gallery")),
+        getCountFromServer(collection(db, "users")),
+        getCountFromServer(collection(db, "gallery")),
         getDocs(query(collection(db, "gallery"), orderBy("createdAt", "desc"), limit(5)))
       ]);
 
       return {
-        totalUsers: usersSnapshot.size,
-        totalGalleryItems: gallerySnapshot.size,
+        totalUsers: usersSnapshot.data().count,
+        totalGalleryItems: gallerySnapshot.data().count,
         recentItems: recentItemsSnapshot.docs.map(doc => ({
           id: doc.id,
           ...doc.data()


### PR DESCRIPTION
💡 **What:** 
Replaced `getDocs` with `getCountFromServer` in the `getStats` method of `FirebaseService`.

🎯 **Why:** 
The previous implementation fetched all documents from the "users" and "gallery" collections just to count them. This is inefficient in terms of bandwidth and memory, especially as the collections grow. `getCountFromServer` is a server-side aggregation that is much faster and cheaper.

📊 **Measured Improvement:** 
Since live benchmarking against the production database is not possible in this environment, I created a verification test (`lib/firebase-service.stats.test.ts`) that mocks the Firestore calls.
- **Baseline:** Validated that the original code called `getDocs` 3 times (users, gallery, recentItems).
- **Optimized:** Validated that the new code calls `getCountFromServer` 2 times (users, gallery) and `getDocs` 1 time (recentItems).
This confirms the bandwidth reduction from O(N) document reads to O(1) aggregation queries for the counts.

---
*PR created automatically by Jules for task [1934131928867497806](https://jules.google.com/task/1934131928867497806) started by @Nandan-D14*